### PR TITLE
Add README and type modal props

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# MarketPulse
+
+This repository contains a single React component written in TypeScript that renders a market dashboard. It displays simulated pricing for stocks, cryptocurrencies, commodities and forex pairs.
+
+The main component `Index` manages mock data and provides interactive features such as search, category filtering, and the ability to add custom symbols. Clicking an item opens `StockDetailModal` which shows a simulated price chart.
+
+To use the code, import `Index` into a React application. The component uses Tailwind CSS for styling and depends on icons from `lucide-react`.
+
+```
+import Index from './market-pulse-dashboard';
+```
+
+Because this repository does not include a build setup or dependencies, integrate the component into an existing React project that has TypeScript, Tailwind CSS and `lucide-react` installed.

--- a/market-pulse-dashboard.tsx
+++ b/market-pulse-dashboard.tsx
@@ -10,7 +10,14 @@ interface MarketItem {
   category: 'stocks' | 'crypto' | 'commodities' | 'forex';
 }
 
-const StockDetailModal = ({ isOpen, onClose, symbol, marketData }) => {
+interface StockDetailModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  symbol: string;
+  marketData: MarketItem[];
+}
+
+const StockDetailModal: React.FC<StockDetailModalProps> = ({ isOpen, onClose, symbol, marketData }) => {
   if (!isOpen) return null;
 
   const stockData = marketData.find(item => item.symbol === symbol);


### PR DESCRIPTION
## Summary
- document how to use the MarketPulse dashboard
- add an interface for StockDetailModal props for better type safety

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c68240278832b88ba615af48ded4b